### PR TITLE
Added macros @process, @event, and @run!

### DIFF
--- a/examples/ccenter.jl
+++ b/examples/ccenter.jl
@@ -47,8 +47,8 @@ s2 = Server(2, M_b, 0.0)
 # process!(clock, Prc(2, serve, s2, input, output, N))
 # event!(clock, fun(arrive, clock, input, count), every, M_arr)
 # run!(clock, 5000)
-@process 1 serve(clock, s1, input, output, N)
-@process 2 serve(clock, s2, input, output, N)
+@process serve(clock, s1, input, output, N)
+@process serve(clock, s2, input, output, N)
 @event arrive(clock,input,count) every M_arr
 @run! clock 5000
 

--- a/examples/ccenter.jl
+++ b/examples/ccenter.jl
@@ -43,10 +43,14 @@ input = Channel{Caller}(Inf)
 output = Caller[]
 s1 = Server(1, M_a, 0.0)
 s2 = Server(2, M_b, 0.0)
-process!(clock, Prc(1, serve, s1, input, output, N))
-process!(clock, Prc(2, serve, s2, input, output, N))
-event!(clock, fun(arrive, clock, input, count), every, M_arr)
-run!(clock, 5000)
+# process!(clock, Prc(1, serve, s1, input, output, N))
+# process!(clock, Prc(2, serve, s2, input, output, N))
+# event!(clock, fun(arrive, clock, input, count), every, M_arr)
+# run!(clock, 5000)
+@process clock Prc(1, serve, s1, input, output, N)
+@process clock Prc(2, serve, s2, input, output, N)
+@event clock fun(arrive, clock, input, count) every M_arr
+@run! clock 5000
 
 # using Plots
 # wt = [c.t₂ - c.t₁ for c in output]

--- a/examples/ccenter.jl
+++ b/examples/ccenter.jl
@@ -47,9 +47,9 @@ s2 = Server(2, M_b, 0.0)
 # process!(clock, Prc(2, serve, s2, input, output, N))
 # event!(clock, fun(arrive, clock, input, count), every, M_arr)
 # run!(clock, 5000)
-@process clock Prc(1, serve, s1, input, output, N)
-@process clock Prc(2, serve, s2, input, output, N)
-@event clock fun(arrive, clock, input, count) every M_arr
+@process 1 serve(clock, s1, input, output, N)
+@process 2 serve(clock, s2, input, output, N)
+@event arrive(clock,input,count) every M_arr
 @run! clock 5000
 
 # using Plots

--- a/examples/intro.jl
+++ b/examples/intro.jl
@@ -26,7 +26,7 @@ input = Channel{Int}(Inf)
 output = Channel{Int}(Inf)
 for i in 1:3      # start three server processes
     # process!(clock, Prc(i, serve, i, input, output, Exponential(1/μ)))
-    @process i serve(clock, i, input, output, Exponential(1/μ))
+    @process serve(clock, i, input, output, Exponential(1/μ))
 end
 # create a repeating event for 10 arrivals
 # event!(clock, fun(arrive, clock, input, count), every, Exponential(1/λ), n=10)

--- a/examples/intro.jl
+++ b/examples/intro.jl
@@ -26,9 +26,9 @@ input = Channel{Int}(Inf)
 output = Channel{Int}(Inf)
 for i in 1:3      # start three server processes
     # process!(clock, Prc(i, serve, i, input, output, Exponential(1/μ)))
-    @process clock Prc(i, serve, i, input, output, Exponential(1/μ))
+    @process i serve(clock, i, input, output, Exponential(1/μ))
 end
 # create a repeating event for 10 arrivals
 # event!(clock, fun(arrive, clock, input, count), every, Exponential(1/λ), n=10)
-@event clock fun(arrive, clock, input, count) every Exponential(1/λ) 10
+@event arrive(clock, input, count) every Exponential(1/λ) 10
 @run! clock 20   # run the clock

--- a/examples/intro.jl
+++ b/examples/intro.jl
@@ -25,8 +25,10 @@ clock = Clock()   # create a clock
 input = Channel{Int}(Inf)
 output = Channel{Int}(Inf)
 for i in 1:3      # start three server processes
-    process!(clock, Prc(i, serve, i, input, output, Exponential(1/μ)))
+    # process!(clock, Prc(i, serve, i, input, output, Exponential(1/μ)))
+    @process clock Prc(i, serve, i, input, output, Exponential(1/μ))
 end
 # create a repeating event for 10 arrivals
-event!(clock, fun(arrive, clock, input, count), every, Exponential(1/λ), n=10)
-run!(clock, 20)   # run the clock
+# event!(clock, fun(arrive, clock, input, count), every, Exponential(1/λ), n=10)
+@event clock fun(arrive, clock, input, count) every Exponential(1/λ) 10
+@run! clock 20   # run the clock

--- a/examples/invctrl.jl
+++ b/examples/invctrl.jl
@@ -57,9 +57,12 @@ const X = TruncatedNormal(μ, σ, a, Inf)  # demand distribution
 
 clock = Clock()
 s = Station(Q, Float64[0.0], Float64[Q], 0, 0, 0.0, 0.0)
-event!(clock, fun(replenish, clock, s, Q), every, M₂)
-event!(clock, fun(customer, clock, s, X), every, M₁)
-println(run!(clock, 5000))
+# event!(clock, fun(replenish, clock, s, Q), every, M₂)
+# event!(clock, fun(customer, clock, s, X), every, M₁)
+# println(run!(clock, 5000))
+@event clock fun(replenish, clock, s, Q) every M₂
+@event clock fun(customer, clock, s, X) every M₁
+println(@run! clock 5000)
 
 @show fuel_sold = s.qs;
 @show loss_rate = s.ql/s.qs;

--- a/examples/invctrl.jl
+++ b/examples/invctrl.jl
@@ -53,15 +53,15 @@ const a = 5        #   minimum amount
 const Q = 6000.0   # replenishment amount
 const M₁ = Exponential(1/λ)  # customer arrival time distribution
 const M₂ = Exponential(1/ρ)  # replenishment time distribution
-const X = TruncatedNormal(μ, σ, a, Inf)  # demand distribution
+const X = truncated(Normal(μ, σ), a, Inf)  # demand distribution
 
 clock = Clock()
 s = Station(Q, Float64[0.0], Float64[Q], 0, 0, 0.0, 0.0)
 # event!(clock, fun(replenish, clock, s, Q), every, M₂)
 # event!(clock, fun(customer, clock, s, X), every, M₁)
 # println(run!(clock, 5000))
-@event clock fun(replenish, clock, s, Q) every M₂
-@event clock fun(customer, clock, s, X) every M₁
+@event replenish(clock, s, Q) every M₂
+@event customer(clock, s, X) every M₁
 println(@run! clock 5000)
 
 @show fuel_sold = s.qs;

--- a/src/DiscreteEvents.jl
+++ b/src/DiscreteEvents.jl
@@ -53,6 +53,7 @@ include("timer.jl")
 include("printing.jl")
 include("resources.jl")
 include("utils.jl")
+include("macros.jl")
 
 export  Clock, PClock, RTClock, setUnit!, 𝐶,
         Action, Timing, at, after, every, before, until,
@@ -63,7 +64,8 @@ export  Clock, PClock, RTClock, setUnit!, 𝐶,
         createRTClock, stopRTClock, 
         PrcException, 
         Resource,
-        onthread, pseed!
+        onthread, pseed!,
+        @process, @event, @run!
 
 
 Random.seed!(123)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -5,13 +5,18 @@ Create a process from a function.
 
 Note: the first arg to the function being passed must be an AbstractClock
 """
-macro process(id, expr)
+macro process(expr, args...)
     expr.head != :call && error("Expression is not a function call.")
     f = expr.args[1] #extract function passed
     c = expr.args[2] #first function arg must be an AbstractClock
-    args = expr.args[3:end] #extract other function args
-    p = :(Prc($id, $f, $(args...))) #create Prc struct
-    esc(:(process!($c,$p))) #execute process!
+    fargs = expr.args[3:end] #extract other function args
+    p = :(Prc($f, $(fargs...))) #create Prc struct
+    if isempty(args)
+        esc(:(process!($c,$p))) #execute process!
+    else
+        cycles = args[1] #extract cycle
+        esc(:(process!($c,$p,$cycles))) #execute process!
+    end
 end
 
 """
@@ -28,18 +33,38 @@ macro event(expr, args...)
     c = expr.args[2] #first function arg must be an AbstractClock
     fargs = expr.args[2:end] #extract other function args
     ex = :(fun($f, $(fargs...))) #create Action
-    if length(args) <= 2 
-        esc(:(event!($c, $ex, $(args...)))) #execute event!
+    if length(args) == 3 
+        esc(:(event!($c, $ex, $(args[1:2]...), n = $args[3]))) #execute event!
     else
-        esc(:(event!($c, $ex, $(args[1:2]...), n = $args[end]))) #execute event!
+        esc(:(event!($c, $ex, $(args...)))) #execute event!
     end
+end
+
+"""
+    @delay
+
+Delay a process.
+"""
+macro delay(clk, delay...)
+    esc(:(delay!($clk, $(delay...))))
+end
+
+"""
+    @wait
+
+Delay a process until a condition has been met.
+"""
+macro wait(clk, cond)
+    exc(:(wait!($clk, $cond)))
 end
 
 """
     @run!
 
 Run a simulation for a given duration.
+
+Takes two arguments: clock and duration.
 """
 macro run!(clk, duration)
-    return esc(:(run!($clk, $duration)))
+    esc(:(run!($clk, $duration)))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,0 +1,41 @@
+"""
+    @proceses
+
+Register a process to a clock.
+"""
+macro process(c, p, cycles=Inf)
+    return esc(:(process!($c, $p, $cycles)))
+end
+
+"""
+    @event
+
+Schedule an event for a given time `t`.
+"""
+macro event(clk, ex, t) 
+    # Cases: 1 - 2
+    # t is Number or Distribution
+    return esc(:(event!($clk, $ex, $t)))
+end
+
+macro event(clk, ex, t, cy, n) 
+    # Cases: 3 - 5 (when n is specified)
+    # t and cy are Numbers or Distributions
+    return esc(:(event!($clk, $ex, $t, $cy; n = $n)))
+end
+
+macro event(clk, ex, T, t) 
+    # Cases: 3 - 7
+    # T is timing or Numbers or Distributions
+    # t is Number or Distribution
+    return esc(:(event!($clk, $ex, $T, $t)))
+end
+
+"""
+    @run!
+
+Run a simulation for a given duration.
+"""
+macro run!(clk, duration)
+    return esc(:(run!($clk, $duration)))
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -130,7 +130,7 @@ mutable struct Prc
     arg::Tuple
     kw::Base.Iterators.Pairs
 
-    Prc( id, f::Function, arg...; kw...) = new(id, nothing, nothing, f, arg, kw)
+    Prc(id, f::Function, arg...; kw...) = new(id, nothing, nothing, f, arg, kw)
 end
 
 """


### PR DESCRIPTION
Had to preserve the `!` for `@run!` because `@run` clashes with VSCodeServer's `@run`.
Updated the first 3 examples to use these macros.
Did not create macros for `fun` or `Prc` because this would require adding a line before `@event` or `@process` to create the `fun` or `Prc`.
Did not include kwargs in the macros as macros do not accept kwargs. The only exception is `@event`, which can take as its last argument `n` for cases 3-5.